### PR TITLE
Fix Mac CI warning

### DIFF
--- a/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
+++ b/src/systems/optical_tactile_plugin/OpticalTactilePlugin.cc
@@ -523,10 +523,9 @@ void OpticalTactilePluginPrivate::Load(const EntityComponentManager &_ecm)
 }
 
 //////////////////////////////////////////////////
-void OpticalTactilePluginPrivate::Enable(const bool _value)
+void OpticalTactilePluginPrivate::Enable(const bool /*_value*/)
 {
-    // todo(mcres) Implement method
-    _value;
+  // todo(mcres) Implement method
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
PR as promised in https://github.com/mcres/ign-gazebo/pull/1#issuecomment-713727874.
So there isn't much to PR, since Addisu okayed us on the `Load()` call. It's just a one liner change for Mac CI to go green.
Merging this should update the upstream PR, and I'll rerun CI on there.
Thanks!